### PR TITLE
Fix grafting url targets

### DIFF
--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -330,9 +330,9 @@ templates:
           handler: handleOwnershipTransferred
         - event: UpdatedMetadataRenderer(address,address)
           handler: handleUpdatedMetadataRenderer
-{{#grafting}}
 features:
   - grafting
+{{#grafting}}
 graft:
   base: {{base}} # subgraph ID of base subgraph
   block: {{block}} # block number


### PR DESCRIPTION
Currently grafting URL targets don't work with new deploy script, this fixes it.