### PR TITLE
Update creator for 1155 premint

### DIFF
--- a/src/ERC1155Mappings/factoryMappings.ts
+++ b/src/ERC1155Mappings/factoryMappings.ts
@@ -35,7 +35,8 @@ export function handleNewContractCreated(event: SetupNewContract): void {
   createdContract.address = event.params.newContract;
   createdContract.contractStandard = TOKEN_STANDARD_ERC1155;
   createdContract.contractURI = event.params.contractURI;
-  createdContract.creator = event.params.creator;
+  // The creator being msg.sender cannot be guaranteed for premint 
+  createdContract.creator = event.params.defaultAdmin;
   createdContract.initialDefaultAdmin = event.params.defaultAdmin;
   createdContract.owner = event.params.defaultAdmin;
   createdContract.name = event.params.name;

--- a/src/ERC721Mappings/ERC721FactoryMappings.ts
+++ b/src/ERC721Mappings/ERC721FactoryMappings.ts
@@ -125,7 +125,7 @@ export function handleCreatedDrop(event: CreatedDrop): void {
     createdContract.contractURI = contractURIResponse.value;
   }
   createdContract.creator = event.params.creator;
-  createdContract.initialDefaultAdmin = dropContract.DEFAULT_ADMIN_ROLE();
+  createdContract.initialDefaultAdmin = event.params.creator;
   createdContract.owner = dropContract.owner();
   createdContract.name = dropContract.name();
   createdContract.symbol = dropContract.symbol();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1931,9 +1931,9 @@ dotenv@^9.0.0:
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz"
   integrity sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==
 
-"ds-test@git+https://github.com/dapphub/ds-test.git#cd98eff28324bfac652e63a239a60632a761790b":
+"ds-test@https://github.com/dapphub/ds-test#cd98eff28324bfac652e63a239a60632a761790b":
   version "1.0.0"
-  resolved "git+https://github.com/dapphub/ds-test.git#cd98eff28324bfac652e63a239a60632a761790b"
+  resolved "https://github.com/dapphub/ds-test#cd98eff28324bfac652e63a239a60632a761790b"
 
 eastasianwidth@^0.2.0:
   version "0.2.0"
@@ -2284,9 +2284,9 @@ forever-agent@~0.6.1:
   resolved "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-"forge-std@git+https://github.com/foundry-rs/forge-std.git#cd7d533f9a0ee0ec02ad81e0a8f262bc4203c653":
+"forge-std@https://github.com/foundry-rs/forge-std#cd7d533f9a0ee0ec02ad81e0a8f262bc4203c653":
   version "1.1.1"
-  resolved "git+https://github.com/foundry-rs/forge-std.git#cd7d533f9a0ee0ec02ad81e0a8f262bc4203c653"
+  resolved "https://github.com/foundry-rs/forge-std#cd7d533f9a0ee0ec02ad81e0a8f262bc4203c653"
 
 form-data-encoder@^2.1.2:
   version "2.1.4"


### PR DESCRIPTION
Updating createdContract.creator on 1155 as in premint it is not guaranteed that msg.sender is the creator. Also updates the initialDefaultAdmin on 721. 

https://linear.app/ourzora/issue/PRO-384/subgraph-creator-for-1155-premint-is-broken