### PR TITLE
refactor: update premint paths

### DIFF
--- a/src/ERC1155Mappings/premintMappings.ts
+++ b/src/ERC1155Mappings/premintMappings.ts
@@ -1,6 +1,6 @@
-import { Premint } from "../../../generated/schema";
-import { Preminted } from "../../../generated/templates/ZoraCreator1155PremintExecutorImpl/ZoraCreator1155PremintExecutorImpl";
-import { getTokenId } from "../../common/getTokenId";
+import { Premint } from "../../generated/schema";
+import { Preminted } from "../../generated/ZoraCreator1155PremintExecutorV1/ZoraCreator1155PremintExecutorImpl";
+import { getTokenId } from "../common/getTokenId";
 
 export function handlePreminted(event: Preminted): void {
   const premint = new Premint(

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -91,7 +91,7 @@ dataSources:
 {{/factories721}}
 {{#preminter}}
   - kind: ethereum/contract
-    name: ZoraCreator1155PremintExecutor{{version}}
+    name: ZoraCreator1155PremintExecutorV{{version}}
     network: {{network}}
     source:
       address: "{{address}}"
@@ -103,7 +103,7 @@ dataSources:
       language: wasm/assemblyscript
       entities:
         - Premint
-      file: ./src/ERC1155Mappings/templates/ZoraPremintMappings.ts
+      file: ./src/ERC1155Mappings/premintMappings.ts
       abis:
         - name: ZoraCreator1155PremintExecutorImpl
           file: ./abis/ZoraCreator1155PremintExecutorImpl.json


### PR DESCRIPTION
Done in this PR:
- Fixed:`Preminted` event import path (build was breaking)
- Nit: Added `V` prefix to premint version for consistency
- Nit: Moved premint mappings out of templates and alongside factory mappings to better reflect architecture