### PR TITLE
Remove Goldsky deployment integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,26 +25,18 @@ NETWORK=zora yarn run build
 NETWORK needs to be a name of a valid network configuration file in `config/`.
 
 
-After building, you can use the graph cli or goldsky cli to deploy the built subgraph for the network specified above.
+After building, you can use the graph cli to deploy the built subgraph for the network specified above.
 
 
-## Deployment shortcuts
+## Build shortcuts
 
-Only supports goldsky deploys for now:
+Builds for specific networks:
 
-Grafts subgraph from FROM_VERSION:
+./scripts/multideploy.sh NETWORKS
 
-./scripts/multideploy.sh NEW_VERSION NETWORKS FROM_VERSION
+./scripts/multideploy.sh zora-testnet,optimism-goerli,base-goerli
 
-./scripts/multideploy.sh 1.10.0 zora-testnet,optimism-goerli,base-goerli 1.8.0
+Builds for all networks:
 
-Deploys without grafting:
-
-./scripts/multideploy.sh NEW_VERSION NETWORKS
-
-./scripts/multideploy.sh 1.10.0 zora-testnet,optimism-goerli,base-goerli
-
-Deploys a new version for _all_ networks without grafting: (not typical, indexing takes a long time in many cases.)
-
-./scripts/multideploy.sh NEW_VERSION
+./scripts/multideploy.sh
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@zoralabs/zora-1155-contracts": "2.6.0"
   },
   "devDependencies": {
-    "@goldskycom/cli": "^7.1.0",
     "@graphprotocol/graph-cli": "0.48.0",
     "matchstick-as": "^0.5.1",
     "yamljs": "^0.3.0",

--- a/scripts/multideploy.sh
+++ b/scripts/multideploy.sh
@@ -1,22 +1,10 @@
-# requirements: jq, curl, goldsky cli
+# requirements: jq
 
 # enable errors
 set -e
 
-# arg 1 = version
-version=$1
-# arg 2 (optional) = networks
-networks=$2
-# arg 3 (optional) = fromversion
-fromversion=$3
-# arg 4 (optional) = fromcontract
-fromcontract=$4
-
-blockbuffer=10
-
-
-# production network tag
-prodtag=stable
+# arg 1 (optional) = networks
+networks=$1
 
 networkfiles=()
 if [[ -n $networks ]]
@@ -31,49 +19,13 @@ else
 fi
 
 
-function getSubgraphQueryPath() {
-  network=$1
-  echo "https://api.goldsky.com/api/public/project_clhk16b61ay9t49vm6ntn4mkz/subgraphs/zora-create-$network/$fromversion/gn"
-}
-
-function getDeploymentBlock() {
-  response=$(curl -sS $1 -X POST -H 'Accept: application/json' -H 'content-type: application/json' --data-raw '{"query":"{\n  _meta{\n    block {\n      number\n    }\n    deployment\n  }\n}"}')
-  echo $response | jq '.data._meta.block.number' -r
-}
-
-function getDeploymentBase() {
-  response=$(curl -sS $1 -X POST -H 'Accept: application/json' -H 'content-type: application/json' --data-raw '{"query":"{\n  _meta{\n    block {\n      number\n    }\n    deployment\n  }\n}"}')
-  echo $response | jq '.data._meta.deployment' -r
-}
-
-function getNetworkDeploymentBlock() {
-  startBlock=$(cat config/$1.json | jq "$fromcontract | map(.startBlock | tonumber) | max")
-  echo $startBlock
-}
-
-
 for element in ${networkfiles[@]}
 do
   filename=$(basename $element)
   network="${filename%.*}"
-  base=$(getSubgraphQueryPath $network)
   # newjson=""
-  graft_flags=""
-  if [[ -n $fromcontract ]]; then
-    # newjson="$(jq '. + {"grafting": {"base": "'$(getDeploymentBase $base)'", "block": '$(($(getNetworkDeploymentBlock $network) - $blockbuffer))'}}' ./config/$network.json)"
-    graft_flags="--graft-from zora-create-$network/$fromversion --start-block $(($(getNetworkDeploymentBlock $network) - $blockbuffer))"
-  elif [[ -z $fromversion ]]; then
-    echo 'skipping grafting'
-    graft_flags="--remove-graft" 
-    # newjson="$(jq 'del(.grafting)' ./config/$network.json)"
-  else
-    # newjson="$(jq '. + {"grafting": {"base": "'$(getDeploymentBase $base)'", "block": '$(($(getDeploymentBlock $base) - $blockbuffer))'}}' ./config/$network.json)"
-    graft_flags="--graft-from zora-create-$network/$fromversion --start-block $(($(getDeploymentBlock $base) - $blockbuffer))"
-  fi
   # echo $newjson
   # echo "$newjson" > ./config/$network.json
   cat ./config/$network.json
   NETWORK=$network yarn run build
-  echo goldsky subgraph deploy zora-create-$network/$version $graft_flags
-  goldsky subgraph deploy zora-create-$network/$version $graft_flags
 done

--- a/yarn.lock
+++ b/yarn.lock
@@ -413,14 +413,6 @@
     graphql-import-node "^0.0.5"
     js-yaml "^4.1.0"
 
-"@goldskycom/cli@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@goldskycom/cli/-/cli-7.1.0.tgz#aa5e8ea618a0c5b7e029c01185db32f116a21464"
-  integrity sha512-5ypEeQMRqDyVhMugIi0/Y2AGz9p/UPuSwEtA3ywf6eOAG6WWT5oBavrrTY/XCbntq9pLlQ9xtoQPyldQdGYpGA==
-  dependencies:
-    cuid "^2.1.8"
-    parse-duration "^1.0.3"
-    readline-sync "^1.4.10"
 
 "@graphprotocol/graph-cli@0.48.0":
   version "0.48.0"


### PR DESCRIPTION
## Summary
- Remove Goldsky deploy targets from multideploy script
- Remove Goldsky dependencies from package.json
- Remove Goldsky docs from README
- Part of org-wide Goldsky removal (1155 NFTs deprecated)

Fixes [BPF-974](https://linear.app/ourzora/issue/BPF-974)