### PR TITLE
Add Goldsky deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,9 @@ Deploys a new version for _all_ networks without grafting: (not typical, indexin
 
 ./scripts/multideploy.sh NEW_VERSION
 
+
+## Deprecation Notice: Goldsky
+
+The Goldsky deployment integration previously used in this repository has been deprecated. The service contract with Goldsky has been terminated and all associated subgraph endpoints and CLI tooling are no longer active.
+
+Existing Goldsky-related code, deployment scripts, and configuration remain in the repository for historical reference. For subgraph deployments, use The Graph CLI directly.


### PR DESCRIPTION
## Summary

- Adds a deprecation notice to the README documenting that the Goldsky subgraph integration has been deprecated and the service contract terminated
- Existing Goldsky-related code is retained as historical reference

Replaces #85 — code removal deferred in favor of a documentation-only approach.